### PR TITLE
Add a Proguard rule to keep Protobuf classes as-is.

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,17 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# AndroidX Security delegates crypto operation to Tink which
+# depends on Protobuf Javalite. Recently Protobuf Javalite
+# introduced a change that relies on reflection, which doesn't
+# work with Proguard.
+# This rule keeps the (shaded) Protobuf classes in Tink as-is.
+# See also:
+# - https://github.com/google/tink/issues/361
+# - https://github.com/protocolbuffers/protobuf/issues/6463
+# - https://b.corp.google.com/issues/144631039
+-keep class * extends com.google.crypto.tink.shaded.protobuf.GeneratedMessageLite {
+  *;
+}
+

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,12 +24,14 @@
 # depends on Protobuf Javalite. Recently Protobuf Javalite
 # introduced a change that relies on reflection, which doesn't
 # work with Proguard.
-# This rule keeps the (shaded) Protobuf classes in Tink as-is.
+# This rule keeps the reflection usages in (shaded) Protobuf
+# classes in Tink as-is.
 # See also:
+# - https://buganizer.corp.google.com/issues/154315507
 # - https://github.com/google/tink/issues/361
 # - https://github.com/protocolbuffers/protobuf/issues/6463
 # - https://b.corp.google.com/issues/144631039
--keep class * extends com.google.crypto.tink.shaded.protobuf.GeneratedMessageLite {
-  *;
+-keepclassmembers class * extends com.google.crypto.tink.shaded.protobuf.GeneratedMessageLite {
+  <fields>;
 }
 


### PR DESCRIPTION
AndroidX Security delegates crypto operation to Tink which
depends on Protobuf Javalite. Recently Protobuf Javalite
introduced a change that relies on reflection, which doesn't
work with Proguard.

This change adds a rule that keeps the (shaded) Protobuf
classes in Tink as-is.

See also:
 - https://buganizer.corp.google.com/issues/154315507
 - https://github.com/google/tink/issues/361
 - https://github.com/protocolbuffers/protobuf/issues/6463
 - https://b.corp.google.com/issues/144631039